### PR TITLE
Clarify that the `def` event handler accepts other types

### DIFF
--- a/events.md
+++ b/events.md
@@ -767,7 +767,7 @@ def on_cvar(value); end
 
 ### `def`
 
-`def` is a parser event that represents defining a regular method on the current self object. It accepts as arguments an [ident](#ident) node (the name of the method being defined), a [params](#params) node (the parameter declaration for the method), and a [bodystmt](#bodystmt) node which represents the statements inside the method. As an example, here are the parts that go into this:
+`def` is a parser event that represents defining a regular method on the current self object. It accepts as arguments an identifier naming the method being defined, a [params](#params) node (the parameter declaration for the method), and a [bodystmt](#bodystmt) node which represents the statements inside the method. As an example, here are the parts that go into this:
 
 ```ruby
 def method(param) do result end
@@ -783,7 +783,7 @@ def method = result
 
 In this case `method` would be the [ident](#ident), the [params](#params) node would be `nil` since this single-line method doesn't declare any parameters, and the final parameter would just be a [vcall](#vcall) for the `result` method.
 
-The handler for this event accepts the [ident](#ident) and optional [params](#params) nodes (note that this will be a [paren](#paren) node containing the [params](#params) node if parentheses are used in the declaration). It also accepts the statements, which can either be a [bodystmt](#bodystmt) node in the case of a multi-line method declaration or any Ruby expression in the case of a single-line statement.
+The handler for this event accepts the identifier (either [ident](#ident), [const](#const), [op](#op) or [kw](#kw)) and optional [params](#params) nodes (note that this will be a [paren](#paren) node containing the [params](#params) node if parentheses are used in the declaration). It also accepts the statements, which can either be a [bodystmt](#bodystmt) node in the case of a multi-line method declaration or any Ruby expression in the case of a single-line statement.
 
 ```ruby
 def on_def(ident, params, body); end


### PR DESCRIPTION
Thanks so much for this wonderful resource! It's been invaluable while working with ripper.

I recently noticed a small omission in the description of the `def` event. The events page implies that it can only take an `ident` node as its first argument, but I recently learned that there are a few other possibilities:

 - `@const` (e.g. `def Integer(num); end'`
 - `@op` (e.g. `def [](i); end`
 - `@kw` when using reserved words as method names, e.g. `def end; end`

[Looking at `parse.y`](https://github.com/ruby/ruby/blob/89077b4c5a8022ef563e11a7b682a4661dc9278c/parse.y#L2300-L2309) it seems like that should cover it, assuming `tFID` is represented in ripper as `ident`, which it appears to be.

It seems that this is relatively common, as in the `symbol` event, where the text reads:
> In most cases this will be an [`ident`](https://kddnewton.com/ripper-docs/events#ident) node, but if the symbol matches other patterns it can be other scanner events (like [`kw`](https://kddnewton.com/ripper-docs/events#kw) for `:if` or [`ivar`](https://kddnewton.com/ripper-docs/events#ivar) for `:@ivar`).

If you'd rather phrase it like in that section, happy to adjust!