### PR TITLE
Fix relative links in README ...

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Ripper is generated from Ruby's own parsing code, and is distributed with Ruby. 
 
 When Ruby parses source code, it first [scans](https://en.wikipedia.org/wiki/Lexical_analysis) the source code into a series of tokens. When a scanner token is recognized, Ripper dispatches a scanner event. The scanner events are then grouped into parser events by applying the Ruby grammar. When a set of scanner events is grouped (i.e., the production rule in the grammar is reduced), Ripper dispatches a parser event.
 
-Each event will create a node in the syntax tree. For instance, an assignment node ([assign](events#assign)) for `value = 7` would come from scanner nodes for `value` ([ident](events#ident)), `=` ([op](events#op)) and `7` ([int](events#int)). A parser event can group parser events, scanner events, or both.
+Each event will create a node in the syntax tree. For instance, an assignment node ([assign](events.md#assign)) for `value = 7` would come from scanner nodes for `value` ([ident](events.md#ident)), `=` ([op](events.md#op)) and `7` ([int](events.md#int)). A parser event can group parser events, scanner events, or both.
 
 Ruby's parser generator (in `parse.y`) contains [comments for Ripper to use](https://github.com/ruby/ruby/blob/79f9f8326a34e499bb2d84d8282943188b1131bd/parse.y#L1519). When Ripper is compiled, it modifies Ruby's compiler code in `parse.y` based on these comments to make its own compiler code, very similar to Ruby's.
 
@@ -14,8 +14,8 @@ Ripper allows you to define handlers for scanner and parser events, which can le
 
 This document contains notes on various subjects pertaining to Ripper, as well as references for all of the various events and methods that Ripper uses internally. Here is a list of the pages that you can find in this document:
 
-* [Usage](usage) will give you a general overview of how to use Ripper for your own purposes
-* [Naming](naming) will give you an idea of some of the event types that Ripper contains and how they are named
-* [Lists](lists) will help you understand how Ripper represents and parses lists of values
-* [Location](location) explains how to determine source location information inside event handlers
-* [Events](events) contains a reference for every scanner and parser event that Ripper dispatches
+* [Usage](usage.md) will give you a general overview of how to use Ripper for your own purposes
+* [Naming](naming.md) will give you an idea of some of the event types that Ripper contains and how they are named
+* [Lists](lists.md) will help you understand how Ripper represents and parses lists of values
+* [Location](location.md) explains how to determine source location information inside event handlers
+* [Events](events.md) contains a reference for every scanner and parser event that Ripper dispatches


### PR DESCRIPTION
... maybe they worked previously without the `.md` extension? At least now they don't work on GitHub.

edit: 

i've found there are doubts about this fix in #3, but can't judge whether they apply.

edit 2:

i guess they would as e.g. `https://kddnewton.com/ripper-docs/events.md` gives me raw text. maybe we can have some JS to fix them on the website? or put a link at the top of the readme like `if you're reading this on github, please go to https://kddnewton.com/ripper-docs`?